### PR TITLE
fix:ubuntu環境の依存パッケージに必要なものを追加

### DIFF
--- a/docs/contribution-guide.md
+++ b/docs/contribution-guide.md
@@ -53,7 +53,7 @@ brew install libwebkit2gtk-4.0 cmake
 
 ```bash
 sudo apt update
-sudo apt install -y libwebkit2gtk-4.0-dev build-essential curl wget file libssl-dev libsoup-3.0-dev
+sudo apt install -y libwebkit2gtk-4.1-dev build-essential curl wget file libssl-dev libsoup-3.0-dev
 ```
 
 ---

--- a/docs/contribution-guide.md
+++ b/docs/contribution-guide.md
@@ -53,7 +53,7 @@ brew install libwebkit2gtk-4.0 cmake
 
 ```bash
 sudo apt update
-sudo apt install -y libwebkit2gtk-4.0-dev build-essential curl wget file libssl-dev
+sudo apt install -y libwebkit2gtk-4.0-dev build-essential curl wget file libssl-dev libsoup-3.0-dev
 ```
 
 ---


### PR DESCRIPTION
手順通りに環境を整えたときに、

`pnpm tauri dev`

を実行するとエラーになったので不足していたパッケージをガイドに追加