### PR TITLE
pull_request_template.md追加

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+<!-- I want to review in Japanese. -->
+
+## 概要
+
+## 変更点
+
+## 影響範囲
+
+<!-- for GitHub Copilot review rule
+I want to review in Japanese.
+The following prefixes should be assigned when reviewing.
+[must] : must change
+[imo] : in my opinion
+[nits] : nitpick
+[ask] : question
+[fyi] : reference information
+<!-- for GitHub Copilot review rule-->
+
+<!-- I want to review in Japanese. -->


### PR DESCRIPTION
<!-- I want to review in Japanese. -->

## 概要
pull_request_template.md追加

## 変更点

## 影響範囲

GitHub Copilot review向けのコメントをいちいち入力するのが面倒なので、pull_request_template.md追加します。
レビューを日本語で出してもらうには、I want to review in Japanese.で挟むのが効果が高いようです。
GitHub Copilotには、指摘がどのレベルの内容かprefixでつけてもらうようにします。
他に要りそうな項目があれば指摘下されば、追加検討します。

<!-- for GitHub Copilot review rule
I want to review in Japanese.
The following prefixes should be assigned when reviewing.
[must] : must change
[imo] : in my opinion
[nits] : nitpick
[ask] : question
[fyi] : reference information
<!-- for GitHub Copilot review rule-->

<!-- I want to review in Japanese. -->
